### PR TITLE
Add Non-blocking example and drop easy-connect

### DIFF
--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/easy-connect/#a7d324f9d80af091f6cfea61b7fa6a6370bdf255

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include "mbed.h"
-#include "easy-connect.h"
 #include "TLSSocket.h"
 #include "NTPClient.h"
 #include "mbed-trace/mbed_trace.h"
@@ -8,19 +7,110 @@ const char* HOST_NAME = "os.mbed.com";
 const int PORT = 443;
 const char* HTTPS_PATH = "/media/uploads/mbed_official/hello.txt";
 
+static void trace_printer(const char* str)
+{
+    printf("%s\r\n", str);
+}
+
+void socket_state_handler(EventFlags *evt, Socket *socket)
+{
+    static char *buf;
+    static int query_len;
+    static int sent;
+    static int received;
+    int ret;
+    static enum {
+        INITIALIZING,
+        //CONNECTING,
+        SEND,
+        RECEIVE,
+        CLOSE,
+        DONE,
+    } next_state = INITIALIZING;
+
+    printf("socket_state_handler() next_state = %d\n", next_state);
+
+    switch (next_state) {
+        case INITIALIZING:
+            buf = new char[1024];
+            query_len = snprintf(buf, 1024,
+                "GET %s HTTP/1.1\n"
+                "Host: %s\n"
+                "Connection: close\n"
+                "\r\n", HTTPS_PATH, HOST_NAME);
+            sent = 0;
+            received = 0;
+            next_state = SEND;
+            // Flow through to SEND
+
+        case SEND:
+            ret = socket->send(buf+sent, query_len-sent);
+            if (ret == NSAPI_ERROR_WOULD_BLOCK) {
+                break;
+            } else if (ret < 0) {
+                next_state = CLOSE; // Error
+                break;
+            }
+            sent += ret;
+            if (sent == query_len) {
+                next_state = RECEIVE;
+                printf("send(): %s\n", buf);
+            }
+            else
+                next_state = SEND;
+            break;
+
+        case RECEIVE:
+            do {
+                ret = socket->recv(buf, 1023);
+                if (ret == NSAPI_ERROR_WOULD_BLOCK) {
+                    break;
+                } else if (ret <= 0) {
+                    next_state = CLOSE; // Error or connection closed
+                    break;
+                }
+                received += ret;
+                buf[ret] = 0;
+                printf("recv() %s\n", buf);
+            } while (ret > 0); // Need to read until WOULD_BLOCK is received, otherwise the state machine stops
+
+            break;
+        case CLOSE:
+            socket->sigio(NULL); // Remove the event handler, we don't want spurious close events anymore.
+            socket->close();
+            printf("connection closed! received total %d bytes\n", received);
+            evt->set(1); // Signal the main thread
+            delete[] buf;
+            next_state = DONE;
+            break;
+        case DONE:
+            // Nothing to do, just allow queued events to flow through
+            break;
+    }
+}
+
+
 int main(int argc, char* argv[]) {
     mbed_trace_init();
+    mbed_trace_print_function_set( trace_printer );
 
     printf("HelloTSLSocket, HTTPS example of TLSSocket\n");
 
     // Open a network interface
-    NetworkInterface* network = NULL;
-    network = easy_connect(true);    // If true, prints out connection details.
+    NetworkInterface* network = NetworkInterface::get_default_instance();
     if (!network) {
-        printf("Unable to open network interface.\n");
+        printf("Error! No network inteface found.\n");
         return -1;
     }
 
+    printf("Connecting to network\n");
+    nsapi_size_or_error_t ret = network->connect();
+    if (ret) {
+        printf("Unable to connect! returned %d\n", ret);
+        return -1;
+    }
+
+    printf("Synchronizing time\n");
     NTPClient ntp(network);
     ntp.set_server("time.google.com", 123);
     time_t now = ntp.get_timestamp();
@@ -43,42 +133,18 @@ int main(int argc, char* argv[]) {
         printf("Failed to connect to the server.\n");
         return -1;
     }
-    
-    const size_t buf_size = 1024;
-    char *buf = new char[buf_size];
+    printf("Connected to %s\n", HOST_NAME);
 
-    // Send HTTP request
-    /* "Connection: close" header is specified to detect end of the body
-     * contents by connection close notification. If this is not specified,
-     * connection is kept, and need to detect end of the content in another
-     * way.
-     */
-    int len = snprintf(buf, buf_size, 
-                "GET %s HTTP/1.1\n"
-                "Host: %s\n"
-                "Connection: close\n"
-                "\n", HTTPS_PATH, HOST_NAME);
-    printf("\r\n%s", buf);
-    int rc = 0;
-    rc = socket.send(buf, len);
-    if(rc < 0) {
-        printf("send error.\n");
-        return -1;
-    }
+    EventFlags completed;
+    EventQueue *queue = mbed_event_queue();
+    Event<void()> handler = queue->event(socket_state_handler, &completed, &socket);
+    socket.set_blocking(false);
+    socket.sigio(handler);
+    handler();                   // Kick the state machine to start connecting
 
-    // Receive response from the server
-    while((rc = socket.recv(buf, buf_size - 1)) > 0) {
-        buf[rc] = '\0';
-        printf("%s", buf);
-    }
-    if(rc < 0) {
-        printf("\r\n! Read failed. err code = %d\n", rc);
-    }
+    completed.wait_any(1);
 
     // Done
     printf("\n");
     printf("HelloTSLSocket DONE.\n");
-    delete[] buf;
-    
-    socket.close();
 }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#63f62165d89f5562c529cd3ecb94823ce1dc7f13
+https://github.com/ARMmbed/mbed-os/#f9862b84e5c7615bf7b2396fd2940f718346493c

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,13 +2,6 @@
     "macros": [
     ],
     "config": {
-        "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
-            "value": "ETHERNET"
-        },
-        "main-stack-size": {
-            "value": 8192
-        },
         "root-ca-cert-pem": {
             "help": "Root CA certificate in PEM format.",
             "value": "\"-----BEGIN CERTIFICATE-----\\nMIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG\\nA1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv\\nb3QgQ0ExGzAZBgNVBAMTEkdsb2JhbFNpZ24gUm9vdCBDQTAeFw05ODA5MDExMjAw\\nMDBaFw0yODAxMjgxMjAwMDBaMFcxCzAJBgNVBAYTAkJFMRkwFwYDVQQKExBHbG9i\\nYWxTaWduIG52LXNhMRAwDgYDVQQLEwdSb290IENBMRswGQYDVQQDExJHbG9iYWxT\\naWduIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDaDuaZ\\njc6j40+Kfvvxi4Mla+pIH/EqsLmVEQS98GPR4mdmzxzdzxtIK+6NiY6arymAZavp\\nxy0Sy6scTHAHoT0KMM0VjU/43dSMUBUc71DuxC73/OlS8pF94G3VNTCOXkNz8kHp\\n1Wrjsok6Vjk4bwY8iGlbKk3Fp1S4bInMm/k8yuX9ifUSPJJ4ltbcdG6TRGHRjcdG\\nsnUOhugZitVtbNV4FpWi6cgKOOvyJBNPc1STE4U6G7weNLWLBYy5d4ux2x8gkasJ\\nU26Qzns3dLlwR5EiUWMWea6xrkEmCMgZK9FGqkjWZCrXgzT/LCrBbBlDSgeF59N8\\n9iFo7+ryUp9/k5DPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8E\\nBTADAQH/MB0GA1UdDgQWBBRge2YaRQ2XyolQL30EzTSo//z9SzANBgkqhkiG9w0B\\nAQUFAAOCAQEA1nPnfE920I2/7LqivjTFKDK1fPxsnCwrvQmeU79rXqoRSLblCKOz\\nyj1hTdNGCbM+w6DjY1Ub8rrvrTnhQ7k4o+YviiY776BQVvnGCv04zcQLcFGUl5gE\\n38NflNUVyRRBnMRddWQVDf9VMOyGj/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymP\\nAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhHhm4qxFYxldBniYUr+WymXUad\\nDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveCX4XSQRjbgbME\\nHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\\n-----END CERTIFICATE-----\""
@@ -16,11 +9,16 @@
     },
     "target_overrides": {
         "*": {
-            "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
-            "mbed-trace.enable": true,
-            "tls-socket.debug-level": 0,
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-wifi-security": "WPA_WPA2",
+            "nsapi.default-wifi-ssid": "\"mbed\"",
+            "nsapi.default-wifi-password": "\"mbed2014\"",
             "platform.stdio-baud-rate": 115200,
-            "platform.stdio-convert-newlines": true
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-buffered-serial": true,
+            "events.shared-stacksize": 5000,
+            "events.shared-eventsize": 2048,
+            "mbed-trace.enable": 1
            }
     }
 }


### PR DESCRIPTION
Example of how to create non-blocking socket communication.

`connect()` and `close()` are still blocking.

This requires https://github.com/ARMmbed/TLSSocket/pull/1

I also removed easy-connect library, as we are phasing out of its use, and I don't want to demonstrate that on new applications.

Btw. This is just for information, I'm not proposing to merge this in.
